### PR TITLE
Expand platform support to amazon to be compatible with Chef13

### DIFF
--- a/libraries/provider_repo.rb
+++ b/libraries/provider_repo.rb
@@ -39,7 +39,7 @@ class NetuitiveCookbook::NetuitiveRepoProvider < Chef::Provider::LWRPBase
         pin 'version ' + new_resource.version
         pin_priority new_resource.repo_priority_pins['debian']
       end
-    when 'rhel', 'fedora'
+    when 'rhel', 'fedora', 'amazon'
       Chef::Log.warn 'EPEL based system support is still in the works, please submit an issue on github for any issues you have'
       # we can only use yum-plugin-versionlock if we enable epel repos
       if new_resource.use_epel_repos


### PR DESCRIPTION
Chef13 reports `platform_family` differently for amazon now