### PR TITLE
AROR-1981 Remove apt dependency

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,8 +4,6 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  apt (3.0.0)
   netuitive (0.17.0)
-    apt (>= 0.0.0)
     yum (>= 0.0.0)
   yum (3.10.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,9 @@ description      'Installs/Configures netuitive'
 long_description 'Installs/Configures netuitive'
 version          '0.19.0'
 
-depends 'apt'
 depends 'yum'
+
+chef_version '>= 13.3'
 
 %w(ubuntu debian centos redhat).each do |os|
   supports os


### PR DESCRIPTION
apt is bundled in chef-client and throws an error now in Chef14.
